### PR TITLE
Use same logic to get gvk of resource object

### DIFF
--- a/pkg/spoke/controllers/manifestwork_controller_test.go
+++ b/pkg/spoke/controllers/manifestwork_controller_test.go
@@ -731,6 +731,11 @@ func TestBuildManifestResourceMeta(t *testing.T) {
 			object:   u,
 			expected: workapiv1.ManifestResourceMeta{},
 		},
+		{
+			name:     "build meta with nil",
+			object:   nil,
+			expected: workapiv1.ManifestResourceMeta{},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This is fllowup of https://github.com/open-cluster-management/work/pull/15/files#r428286111.