### PR TITLE
Add finalizer on role/rolebinding for work agent

### DIFF
--- a/cmd/work/main.go
+++ b/cmd/work/main.go
@@ -13,6 +13,7 @@ import (
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 
+	"github.com/open-cluster-management/work/pkg/cmd/hub"
 	"github.com/open-cluster-management/work/pkg/cmd/spoke"
 	"github.com/open-cluster-management/work/pkg/version"
 )
@@ -49,6 +50,7 @@ func newWorkCommand() *cobra.Command {
 		cmd.Version = v
 	}
 
+	cmd.AddCommand(hub.NewController())
 	cmd.AddCommand(spoke.NewWorkloadAgent())
 
 	return cmd

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/open-cluster-management/api v0.0.0-20200528225735-c85cec6fa5b0

--- a/pkg/cmd/hub/controller.go
+++ b/pkg/cmd/hub/controller.go
@@ -1,0 +1,20 @@
+package hub
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+
+	"github.com/open-cluster-management/work/pkg/hub"
+	"github.com/open-cluster-management/work/pkg/version"
+)
+
+func NewController() *cobra.Command {
+	cmd := controllercmd.
+		NewControllerCommandConfig("work-controller", version.Get(), hub.RunControllerManager).
+		NewCommand()
+	cmd.Use = "controller"
+	cmd.Short = "Start the Work Controller"
+
+	return cmd
+}

--- a/pkg/cmd/spoke/agent.go
+++ b/pkg/cmd/spoke/agent.go
@@ -16,7 +16,7 @@ func NewWorkloadAgent() *cobra.Command {
 		NewControllerCommandConfig("work-agent", version.Get(), o.RunWorkloadAgent).
 		NewCommand()
 	cmd.Use = "agent"
-	cmd.Short = "Start the Cluster Registration Agent"
+	cmd.Short = "Start the Work Agent"
 
 	o.AddFlags(cmd)
 	return cmd

--- a/pkg/hub/controllers/finalizercontroller/finalize_controller.go
+++ b/pkg/hub/controllers/finalizercontroller/finalize_controller.go
@@ -1,0 +1,245 @@
+package finalizercontroller
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	workv1client "github.com/open-cluster-management/api/client/work/clientset/versioned/typed/work/v1"
+	worklister "github.com/open-cluster-management/api/client/work/listers/work/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+const (
+	manifestWorkFinalizer = "cluster.open-cluster-management.io/manifest-work-cleanup"
+)
+
+// RequeueDelay is time to wait before requeue the key
+var RequeueDelay = 1 * time.Minute
+
+// FinalizeController ensures all manifestworks are deleted before role/rolebinding for work
+// agent are deleted in a terminating cluster namespace.
+type FinalizeController struct {
+	roleLister         rbacv1listers.RoleLister
+	roleBindingLister  rbacv1listers.RoleBindingLister
+	rbacClient         rbacv1client.RbacV1Interface
+	namespaceLister    corelisters.NamespaceLister
+	manifestWorkClient workv1client.WorkV1Interface
+	manifestWorkLister worklister.ManifestWorkLister
+	eventRecorder      events.Recorder
+}
+
+func NewFinalizeController(
+	eventRecorder events.Recorder,
+	roleInformer rbacv1informers.RoleInformer,
+	roleBindingInformer rbacv1informers.RoleBindingInformer,
+	namespaceLister corelisters.NamespaceLister,
+	manifestWorkClient workv1client.WorkV1Interface,
+	manifestWorkLister worklister.ManifestWorkLister,
+	rbacClient rbacv1client.RbacV1Interface,
+) factory.Controller {
+
+	controller := &FinalizeController{
+		roleLister:         roleInformer.Lister(),
+		roleBindingLister:  roleBindingInformer.Lister(),
+		namespaceLister:    namespaceLister,
+		manifestWorkClient: manifestWorkClient,
+		manifestWorkLister: manifestWorkLister,
+		rbacClient:         rbacClient,
+		eventRecorder:      eventRecorder,
+	}
+
+	return factory.New().
+		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
+			key, _ := cache.MetaNamespaceKeyFunc(obj)
+			return key
+		}, roleInformer.Informer(), roleBindingInformer.Informer()).
+		WithSync(controller.sync).ToController("FinalizeController", eventRecorder)
+}
+
+func (m *FinalizeController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	key := controllerContext.QueueKey()
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		// ignore role/rolebinding whose key is not in format: namespace/name
+		return nil
+	}
+
+	ns, err := m.namespaceLister.Get(namespace)
+	if err != nil {
+		return err
+	}
+
+	role, rolebinding, err := m.getRoleAndRoleBinding(namespace, name)
+	if err != nil {
+		return err
+	}
+
+	err = m.syncRoleAndRoleBinding(ctx, controllerContext, role, rolebinding, ns)
+
+	if err != nil {
+		klog.Errorf("Reconcile role/rolebinding %s fails with err: %v", key, err)
+	}
+	return err
+}
+
+func (m *FinalizeController) syncRoleAndRoleBinding(ctx context.Context, controllerContext factory.SyncContext,
+	role *rbacv1.Role, rolebinding *rbacv1.RoleBinding, ns *corev1.Namespace) error {
+	key := controllerContext.QueueKey()
+	klog.V(4).Infof("Sync role/rolebinding %s", key)
+
+	// no work if neither role nor rolebinding has the finalizer
+	if !hasFinalizer(role, manifestWorkFinalizer) && !hasFinalizer(rolebinding, manifestWorkFinalizer) {
+		return nil
+	}
+
+	if terminated(ns) {
+		works, err := m.manifestWorkLister.ManifestWorks(ns.Name).List(labels.Everything())
+		if err != nil {
+			return err
+		}
+
+		// requeue the key if there exists any manifest work in cluster namespace
+		if len(works) != 0 {
+			controllerContext.Queue().AddAfter(key, RequeueDelay)
+			klog.V(4).Infof("Requeue role/rolebinding %q after %v", key, RequeueDelay)
+			return nil
+		}
+
+		// remove finalizer from role/rolebinding
+		if err := m.removeFinalizerFromRole(ctx, role, manifestWorkFinalizer); err != nil {
+			return err
+		}
+
+		return m.removeFinalizerFromRoleBinding(ctx, rolebinding, manifestWorkFinalizer)
+	}
+
+	if terminated(role) {
+		if err := m.removeFinalizerFromRole(ctx, role, manifestWorkFinalizer); err != nil {
+			return err
+		}
+	}
+
+	if terminated(rolebinding) {
+		if err := m.removeFinalizerFromRoleBinding(ctx, rolebinding, manifestWorkFinalizer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *FinalizeController) getRoleAndRoleBinding(namespace, name string) (*rbacv1.Role, *rbacv1.RoleBinding, error) {
+	role, err := m.roleLister.Roles(namespace).Get(name)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, nil, err
+	}
+
+	rolebinding, err := m.roleBindingLister.RoleBindings(namespace).Get(name)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, nil, err
+	}
+
+	return role, rolebinding, nil
+}
+
+// removeFinalizerFromRole removes the particular finalizer from role
+func (m *FinalizeController) removeFinalizerFromRole(ctx context.Context, role *rbacv1.Role, finalizer string) error {
+	if role == nil {
+		return nil
+	}
+
+	role = role.DeepCopy()
+	if changed := removeFinalizer(role, finalizer); !changed {
+		return nil
+	}
+
+	_, err := m.rbacClient.Roles(role.Namespace).Update(ctx, role, metav1.UpdateOptions{})
+	return err
+}
+
+// removeFinalizerFromRoleBinding removes the particular finalizer from rolebinding
+func (m *FinalizeController) removeFinalizerFromRoleBinding(ctx context.Context, rolebinding *rbacv1.RoleBinding, finalizer string) error {
+	if rolebinding == nil {
+		return nil
+	}
+
+	rolebinding = rolebinding.DeepCopy()
+	if changed := removeFinalizer(rolebinding, finalizer); !changed {
+		return nil
+	}
+
+	_, err := m.rbacClient.RoleBindings(rolebinding.Namespace).Update(ctx, rolebinding, metav1.UpdateOptions{})
+	return err
+}
+
+// hasFinalizer returns true if the object has the given finalizer
+func hasFinalizer(obj runtime.Object, finalizer string) bool {
+	if obj == nil || reflect.ValueOf(obj).IsNil() {
+		return false
+	}
+
+	accessor, _ := meta.Accessor(obj)
+	for _, f := range accessor.GetFinalizers() {
+		if f == finalizer {
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeFinalizer removes a finalizer from the list. It mutates its input.
+func removeFinalizer(obj runtime.Object, finalizerName string) bool {
+	if obj == nil || reflect.ValueOf(obj).IsNil() {
+		return false
+	}
+
+	newFinalizers := []string{}
+	accessor, _ := meta.Accessor(obj)
+	found := false
+	for _, finalizer := range accessor.GetFinalizers() {
+		if finalizer == finalizerName {
+			found = true
+			continue
+		}
+		newFinalizers = append(newFinalizers, finalizer)
+	}
+	if found {
+		accessor.SetFinalizers(newFinalizers)
+	}
+	return found
+}
+
+// terminated returns true if the DeletionTimestamp of the object is set
+func terminated(obj runtime.Object) bool {
+	if obj == nil || reflect.ValueOf(obj).IsNil() {
+		return false
+	}
+
+	accessor, _ := meta.Accessor(obj)
+	deletionTimestamp := accessor.GetDeletionTimestamp()
+
+	if deletionTimestamp == nil {
+		return false
+	}
+
+	if deletionTimestamp.IsZero() {
+		return false
+	}
+
+	return true
+}

--- a/pkg/hub/controllers/finalizercontroller/finalize_controller_test.go
+++ b/pkg/hub/controllers/finalizercontroller/finalize_controller_test.go
@@ -1,0 +1,187 @@
+package finalizercontroller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	fakeworkclient "github.com/open-cluster-management/api/client/work/clientset/versioned/fake"
+	workinformers "github.com/open-cluster-management/api/client/work/informers/externalversions"
+	workapiv1 "github.com/open-cluster-management/api/work/v1"
+	"github.com/open-cluster-management/work/pkg/hub/hubtesting"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/diff"
+)
+
+func TestSyncRoleAndRoleBinding(t *testing.T) {
+	cases := []struct {
+		name                          string
+		role                          *rbacv1.Role
+		roleBinding                   *rbacv1.RoleBinding
+		namespace                     *corev1.Namespace
+		work                          *workapiv1.ManifestWork
+		expectedRoleFinalizers        []string
+		expectedRoleBindingFinalizers []string
+		expectedWorkFinalizers        []string
+		expectedQueueLen              int
+		validateRabcActions           func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name:                "skip if neither role nor rolebinding exists",
+			namespace:           hubtesting.NewNamespace("cluster1", false),
+			work:                hubtesting.NewManifestWork("cluster1", "work1", nil, nil),
+			validateRabcActions: noAction,
+		},
+		{
+			name:                   "skip if neither role nor rolebinding has finalizer",
+			role:                   hubtesting.NewRole("cluster1", "cluster1:spoke-work", nil, false),
+			roleBinding:            hubtesting.NewRoleBinding("cluster1", "cluster1:spoke-work", nil, false),
+			namespace:              hubtesting.NewNamespace("cluster1", false),
+			work:                   hubtesting.NewManifestWork("cluster1", "work1", []string{manifestWorkFinalizer}, nil),
+			expectedWorkFinalizers: []string{manifestWorkFinalizer},
+			validateRabcActions:    noAction,
+		},
+		{
+			name:                          "remove finalizer from deleting role within non-terminating namespace",
+			role:                          hubtesting.NewRole("cluster1", "cluster1:spoke-work", []string{manifestWorkFinalizer}, true),
+			roleBinding:                   hubtesting.NewRoleBinding("cluster1", "cluster1:spoke-work", []string{manifestWorkFinalizer}, false),
+			namespace:                     hubtesting.NewNamespace("cluster1", false),
+			work:                          hubtesting.NewManifestWork("cluster1", "work1", []string{manifestWorkFinalizer}, nil),
+			expectedRoleBindingFinalizers: []string{manifestWorkFinalizer},
+			expectedWorkFinalizers:        []string{manifestWorkFinalizer},
+			validateRabcActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name:        "remove finalizer from role/rolebinding within terminating namespace",
+			role:        hubtesting.NewRole("cluster1", "cluster1:spoke-work", []string{manifestWorkFinalizer}, true),
+			roleBinding: hubtesting.NewRoleBinding("cluster1", "cluster1:spoke-work", []string{manifestWorkFinalizer}, true),
+			namespace:   hubtesting.NewNamespace("cluster1", true),
+			validateRabcActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name:                          "requeue the key",
+			role:                          hubtesting.NewRole("cluster1", "cluster1:spoke-work", []string{manifestWorkFinalizer}, true),
+			roleBinding:                   hubtesting.NewRoleBinding("cluster1", "cluster1:spoke-work", []string{manifestWorkFinalizer}, true),
+			namespace:                     hubtesting.NewNamespace("cluster1", true),
+			work:                          hubtesting.NewManifestWork("cluster1", "work1", []string{manifestWorkFinalizer}, hubtesting.NewDeletionTimestamp(0)),
+			expectedRoleFinalizers:        []string{manifestWorkFinalizer},
+			expectedRoleBindingFinalizers: []string{manifestWorkFinalizer},
+			expectedWorkFinalizers:        []string{manifestWorkFinalizer},
+			expectedQueueLen:              1,
+			validateRabcActions:           noAction,
+		},
+	}
+
+	// reduce the delay to speed up the testing
+	RequeueDelay = 0
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			objects := []runtime.Object{}
+			if c.role != nil {
+				objects = append(objects, c.role)
+			}
+			if c.roleBinding != nil {
+				objects = append(objects, c.roleBinding)
+			}
+			if c.namespace != nil {
+				objects = append(objects, c.namespace)
+			}
+			fakeClient := fakeclient.NewSimpleClientset(objects...)
+
+			var fakeManifestWorkClient *fakeworkclient.Clientset
+			if c.work == nil {
+				fakeManifestWorkClient = fakeworkclient.NewSimpleClientset()
+			} else {
+				fakeManifestWorkClient = fakeworkclient.NewSimpleClientset(c.work)
+			}
+			workInformerFactory := workinformers.NewSharedInformerFactory(fakeManifestWorkClient, 5*time.Minute)
+
+			recorder := events.NewInMemoryRecorder("")
+			controller := FinalizeController{
+				manifestWorkClient: fakeManifestWorkClient.WorkV1(),
+				manifestWorkLister: workInformerFactory.Work().V1().ManifestWorks().Lister(),
+				eventRecorder:      recorder,
+				rbacClient:         fakeClient.RbacV1(),
+			}
+
+			controllerContext := hubtesting.NewSyncContext("", recorder)
+
+			func() {
+				ctx, cancel := context.WithTimeout(context.TODO(), 15*time.Second)
+				defer cancel()
+
+				workInformerFactory.Start(ctx.Done())
+				workInformerFactory.WaitForCacheSync(ctx.Done())
+
+				controller.syncRoleAndRoleBinding(context.TODO(), controllerContext, c.role, c.roleBinding, c.namespace)
+
+				c.validateRabcActions(t, fakeClient.Actions())
+
+				if c.role != nil {
+					role, err := fakeClient.RbacV1().Roles(c.role.Namespace).Get(context.TODO(), c.role.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					assertFinalizers(t, role, c.expectedRoleFinalizers)
+				}
+
+				if c.roleBinding != nil {
+					rolebinding, err := fakeClient.RbacV1().RoleBindings(c.roleBinding.Namespace).Get(context.TODO(), c.roleBinding.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					assertFinalizers(t, rolebinding, c.expectedRoleBindingFinalizers)
+				}
+
+				if c.work != nil {
+					work, err := fakeManifestWorkClient.WorkV1().ManifestWorks(c.work.Namespace).Get(context.TODO(), c.work.Name, metav1.GetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					assertFinalizers(t, work, c.expectedWorkFinalizers)
+				}
+
+				actual := controllerContext.Queue().Len()
+				if actual != c.expectedQueueLen {
+					t.Errorf("Expect queue with length: %d, but got %d", c.expectedQueueLen, actual)
+				}
+			}()
+		})
+	}
+}
+
+func assertFinalizers(t *testing.T, obj runtime.Object, finalizers []string) {
+	accessor, _ := meta.Accessor(obj)
+	actual := accessor.GetFinalizers()
+	if len(actual) == 0 && len(finalizers) == 0 {
+		return
+	}
+
+	if !reflect.DeepEqual(actual, finalizers) {
+		t.Fatal(diff.ObjectDiff(actual, finalizers))
+	}
+}
+
+func noAction(t *testing.T, actions []clienttesting.Action) {
+	if len(actions) > 0 {
+		t.Fatal(spew.Sdump(actions))
+	}
+}

--- a/pkg/hub/hubtesting/helper.go
+++ b/pkg/hub/hubtesting/helper.go
@@ -1,0 +1,97 @@
+package hubtesting
+
+import (
+	"time"
+
+	workapiv1 "github.com/open-cluster-management/api/work/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func NewRole(namespace, name string, finalizers []string, terminated bool) *rbacv1.Role {
+	role := &rbacv1.Role{}
+
+	role.Namespace = namespace
+	role.Name = name
+	role.Finalizers = finalizers
+	if terminated {
+		now := metav1.Now()
+		role.DeletionTimestamp = &now
+	}
+
+	return role
+}
+
+func NewRoleBinding(namespace, name string, finalizers []string, terminated bool) *rbacv1.RoleBinding {
+	rolebinding := &rbacv1.RoleBinding{}
+
+	rolebinding.Namespace = namespace
+	rolebinding.Name = name
+	rolebinding.Finalizers = finalizers
+	if terminated {
+		now := metav1.Now()
+		rolebinding.DeletionTimestamp = &now
+	}
+
+	return rolebinding
+}
+
+func NewNamespace(name string, terminated bool) *corev1.Namespace {
+	namespace := &corev1.Namespace{}
+	namespace.Name = name
+	if terminated {
+		now := metav1.Now()
+		namespace.DeletionTimestamp = &now
+	}
+
+	return namespace
+}
+
+func NewManifestWork(namespace, name string, finalizers []string, deletionTimestamp *metav1.Time) *workapiv1.ManifestWork {
+	work := &workapiv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              name,
+			Finalizers:        finalizers,
+			DeletionTimestamp: deletionTimestamp,
+		},
+	}
+
+	return work
+}
+
+func NewDeletionTimestamp(offset time.Duration) *metav1.Time {
+	return &metav1.Time{
+		Time: metav1.Now().Add(offset),
+	}
+}
+
+type syncContext struct {
+	eventRecorder events.Recorder
+	queueKey      string
+	queue         workqueue.RateLimitingInterface
+}
+
+func (c syncContext) Queue() workqueue.RateLimitingInterface {
+	return c.queue
+}
+
+func (c syncContext) QueueKey() string {
+	return c.queueKey
+}
+
+func (c syncContext) Recorder() events.Recorder {
+	return c.eventRecorder
+}
+
+func NewSyncContext(queueKey string, eventRecorder events.Recorder) factory.SyncContext {
+	return &syncContext{
+		queueKey:      queueKey,
+		eventRecorder: eventRecorder,
+		queue:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+}

--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -1,0 +1,50 @@
+package hub
+
+import (
+	"context"
+	"time"
+
+	workclientset "github.com/open-cluster-management/api/client/work/clientset/versioned"
+	workinformers "github.com/open-cluster-management/api/client/work/informers/externalversions"
+	"github.com/open-cluster-management/work/pkg/hub/controllers/finalizercontroller"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+// RunControllerManager starts the controllers on hub to manage manifest works.
+func RunControllerManager(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+	// setup kube informers
+	kubeClient, err := kubernetes.NewForConfig(controllerContext.KubeConfig)
+	if err != nil {
+		return err
+	}
+	kubeInformers := kubeinformers.NewSharedInformerFactory(kubeClient, 5*time.Minute)
+
+	// setup work informers
+	workClient, err := workclientset.NewForConfig(controllerContext.KubeConfig)
+	if err != nil {
+		return err
+	}
+	workInformers := workinformers.NewSharedInformerFactory(workClient, 5*time.Minute)
+	workLister := workInformers.Work().V1().ManifestWorks().Lister()
+
+	// create controllers
+	finalizeController := finalizercontroller.NewFinalizeController(
+		controllerContext.EventRecorder,
+		kubeInformers.Rbac().V1().Roles(),
+		kubeInformers.Rbac().V1().RoleBindings(),
+		kubeInformers.Core().V1().Namespaces().Lister(),
+		workClient.WorkV1(),
+		workLister,
+		kubeClient.RbacV1())
+
+	// start informers and controllers
+	go kubeInformers.Start(ctx.Done())
+	go workInformers.Start(ctx.Done())
+
+	go finalizeController.Run(ctx, 1)
+
+	<-ctx.Done()
+	return nil
+}

--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -21,12 +21,15 @@ endif
 clean-integration-test:
 	$(RM) '$(KB_TOOLS_ARCHIVE_PATH)'
 	rm -rf $(TEST_TMP)/kubebuilder
-	$(RM) ./integration.test
+	$(RM) ./hub.test
+	$(RM) ./spoke.test
 .PHONY: clean-integration-test
 
 clean: clean-integration-test
 
 test-integration: ensure-kubebuilder-tools
-	go test -c ./test/integration
-	./integration.test -ginkgo.slowSpecThreshold=15 -ginkgo.v -ginkgo.failFast
+	go test -c ./test/integration/hub/
+	./hub.test -ginkgo.slowSpecThreshold=15 -ginkgo.v -ginkgo.failFast
+	go test -c ./test/integration/spoke/
+	./spoke.test -ginkgo.slowSpecThreshold=15 -ginkgo.v -ginkgo.failFast
 .PHONY: test-integration

--- a/test/integration/hub/finalizer_test.go
+++ b/test/integration/hub/finalizer_test.go
@@ -1,0 +1,186 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workapiv1 "github.com/open-cluster-management/api/work/v1"
+	"github.com/open-cluster-management/work/pkg/hub"
+	"github.com/open-cluster-management/work/pkg/hub/controllers/finalizercontroller"
+	"github.com/open-cluster-management/work/test/integration/util"
+)
+
+const (
+	manifestWorkFinalizer = "cluster.open-cluster-management.io/manifest-work-cleanup"
+)
+
+func startControllerManager(ctx context.Context) {
+	err := hub.RunControllerManager(ctx, &controllercmd.ControllerContext{
+		KubeConfig:    restConfig,
+		EventRecorder: events.NewInMemoryRecorder(""),
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func startFakeWorkAgent(ctx context.Context, clusterName string) {
+	log.Info("Start fake WorkAgent...")
+Loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break Loop
+		default:
+			works, err := workClient.WorkV1().ManifestWorks(clusterName).List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				log.Error(err, "Unable to list works")
+			} else {
+				for _, work := range works.Items {
+					if work.DeletionTimestamp == nil || work.DeletionTimestamp.IsZero() {
+						continue
+					}
+
+					if len(work.Finalizers) == 0 {
+						continue
+					}
+
+					work.Finalizers = nil
+					_, err := workClient.WorkV1().ManifestWorks(clusterName).Update(context.Background(), &work, metav1.UpdateOptions{})
+					if err != nil {
+						log.Error(err, "Unable to update work", "namespace", work.Namespace, "name", work.Name)
+					} else {
+						log.Info("Remove finalizer from work", "namespace", work.Namespace, "name", work.Name)
+					}
+				}
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	log.Info("Fake WorkAgent exited")
+}
+
+var _ = ginkgo.Describe("Finalizer controllers", func() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	var works []*workapiv1.ManifestWork
+	var clusterName string
+	var err error
+
+	ginkgo.BeforeEach(func() {
+		finalizercontroller.RequeueDelay = 1 * time.Second
+
+		// create cluster namespace
+		ns := &corev1.Namespace{}
+		ns.GenerateName = "cluster-"
+		ns, err = kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		clusterName = ns.Name
+
+		// create works
+		for i := 0; i < 5; i++ {
+			work := util.NewManifestWork(clusterName, fmt.Sprintf("work%d", i+1), nil)
+			work.Finalizers = []string{manifestWorkFinalizer}
+			work, err = workClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			works = append(works, work)
+		}
+
+		ctx, cancel = context.WithCancel(context.Background())
+		// start hub controllers
+		go startControllerManager(ctx)
+
+		// create role/rolebinding in cluster namespace
+		role := util.NewRole(clusterName, fmt.Sprintf("%s:spoke-work", clusterName), []string{manifestWorkFinalizer})
+		_, err = kubeClient.RbacV1().Roles(clusterName).Create(context.Background(), role, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		rolebinding := util.NewRoleBinding(clusterName, fmt.Sprintf("%s:spoke-work", clusterName), []string{manifestWorkFinalizer})
+		_, err = kubeClient.RbacV1().RoleBindings(clusterName).Create(context.Background(), rolebinding, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterEach(func() {
+		if cancel != nil {
+			cancel()
+		}
+		ns, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), clusterName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		if ns.DeletionTimestamp == nil || ns.DeletionTimestamp.IsZero() {
+			err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), clusterName, metav1.DeleteOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		}
+	})
+
+	ginkgo.Context("Within terminating namespace", func() {
+		ginkgo.It("should delete both manifest works and role/rolebinding", func() {
+			// start a fake work agent to remove finalizer from works
+			go startFakeWorkAgent(ctx, clusterName)
+
+			deleteNamespace(clusterName)
+			util.AssertNamespaceDeleted(clusterName, kubeClient, workClient, eventuallyTimeout, eventuallyInterval)
+		})
+	})
+
+	ginkgo.Context("Within non-terminating namespace", func() {
+		ginkgo.It("should delete only role/rolebinding and keep existing manifest works", func() {
+			// delete role/rolebinding
+			err = kubeClient.RbacV1().Roles(clusterName).Delete(context.Background(), fmt.Sprintf("%s:spoke-work", clusterName), metav1.DeleteOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			err = kubeClient.RbacV1().RoleBindings(clusterName).Delete(context.Background(), fmt.Sprintf("%s:spoke-work", clusterName), metav1.DeleteOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// check if role/rolebinding are deleted
+			gomega.Eventually(func() bool {
+				_, err = kubeClient.RbacV1().Roles(clusterName).Get(context.Background(), fmt.Sprintf("%s:spoke-work", clusterName), metav1.GetOptions{})
+				if !errors.IsNotFound(err) {
+					return false
+				}
+
+				_, err = kubeClient.RbacV1().RoleBindings(clusterName).Get(context.Background(), fmt.Sprintf("%s:spoke-work", clusterName), metav1.GetOptions{})
+				if !errors.IsNotFound(err) {
+					return false
+				}
+
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// check if works still exist
+			works, err := workClient.WorkV1().ManifestWorks(clusterName).List(context.Background(), metav1.ListOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(works.Items).ToNot(gomega.BeEmpty())
+		})
+	})
+})
+
+func deleteNamespace(namespace string) {
+	// delete namespace
+	err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	// delete works
+	works, err := workClient.WorkV1().ManifestWorks(namespace).List(context.Background(), metav1.ListOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	for _, work := range works.Items {
+		err = workClient.WorkV1().ManifestWorks(namespace).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}
+
+	// delete role/rolebinding
+	err = kubeClient.RbacV1().Roles(namespace).Delete(context.Background(), fmt.Sprintf("%s:spoke-work", namespace), metav1.DeleteOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	err = kubeClient.RbacV1().RoleBindings(namespace).Delete(context.Background(), fmt.Sprintf("%s:spoke-work", namespace), metav1.DeleteOptions{})
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+}

--- a/test/integration/hub/suite_test.go
+++ b/test/integration/hub/suite_test.go
@@ -1,0 +1,86 @@
+package hub
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	workclientset "github.com/open-cluster-management/api/client/work/clientset/versioned"
+	workapiv1 "github.com/open-cluster-management/api/work/v1"
+)
+
+const (
+	eventuallyTimeout  = 30 // seconds
+	eventuallyInterval = 1  // seconds
+)
+
+var restConfig *rest.Config
+var testEnv *envtest.Environment
+var kubeClient kubernetes.Interface
+var workClient workclientset.Interface
+var log logr.Logger
+
+func TestIntegration(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Integration Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func(done ginkgo.Done) {
+	log = zap.LoggerTo(ginkgo.GinkgoWriter, true)
+	logf.SetLogger(log)
+	ginkgo.By("bootstrapping test environment")
+
+	// start a kube-apiserver
+	testEnv = &envtest.Environment{
+		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths: []string{
+			filepath.Join(".", "vendor", "github.com", "open-cluster-management", "api", "work", "v1"),
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(cfg).ToNot(gomega.BeNil())
+
+	/*
+		// create kubeconfig file for hub in a tmp dir
+		tempDir, err = ioutil.TempDir("", "test")
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(tempDir).ToNot(gomega.BeEmpty())
+		hubKubeconfigFileName = path.Join(tempDir, "kubeconfig")
+		err = util.CreateKubeconfigFile(cfg, hubKubeconfigFileName)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		err = apiextensionsv1beta1.AddToScheme(scheme.Scheme)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	*/
+
+	err = workapiv1.AddToScheme(scheme.Scheme)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	restConfig = cfg
+	kubeClient, err = kubernetes.NewForConfig(cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	workClient, err = workclientset.NewForConfig(cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	close(done)
+}, 60)
+
+var _ = ginkgo.AfterSuite(func() {
+	ginkgo.By("tearing down the test environment")
+
+	err := testEnv.Stop()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+})

--- a/test/integration/spoke/suite_test.go
+++ b/test/integration/spoke/suite_test.go
@@ -1,4 +1,4 @@
-package integration
+package spoke
 
 import (
 	"io/ioutil"

--- a/test/integration/spoke/work_test.go
+++ b/test/integration/spoke/work_test.go
@@ -1,4 +1,4 @@
-package integration
+package spoke
 
 import (
 	"context"
@@ -216,11 +216,11 @@ var _ = ginkgo.Describe("ManifestWork", func() {
 			gvrs = append(gvrs, gvr)
 			objects = append(objects, u)
 
-			u, gvr = util.NewRole(o.SpokeClusterName, "role1")
+			u, gvr = util.NewUnstructuredRole(o.SpokeClusterName, "role1")
 			gvrs = append(gvrs, gvr)
 			objects = append(objects, u)
 
-			u, gvr = util.NewRoleBinding(o.SpokeClusterName, "rolebinding1", "sa", "role1")
+			u, gvr = util.NewUnstructuredRoleBinding(o.SpokeClusterName, "rolebinding1", "sa", "role1")
 			gvrs = append(gvrs, gvr)
 			objects = append(objects, u)
 

--- a/test/integration/util/unstructured.go
+++ b/test/integration/util/unstructured.go
@@ -222,7 +222,7 @@ func NewServiceAccount(namespace, name string) (*unstructured.Unstructured, sche
 	return toUnstructured(obj, serviceAccountGVK, scheme), serviceAccountGVR
 }
 
-func NewRole(namespace, name string) (*unstructured.Unstructured, schema.GroupVersionResource) {
+func NewUnstructuredRole(namespace, name string) (*unstructured.Unstructured, schema.GroupVersionResource) {
 	obj := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -240,7 +240,7 @@ func NewRole(namespace, name string) (*unstructured.Unstructured, schema.GroupVe
 	return toUnstructured(obj, roleGVK, scheme), roleGVR
 }
 
-func NewRoleBinding(namespace, name, sa, role string) (*unstructured.Unstructured, schema.GroupVersionResource) {
+func NewUnstructuredRoleBinding(namespace, name, sa, role string) (*unstructured.Unstructured, schema.GroupVersionResource) {
 	obj := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,


### PR DESCRIPTION
Create controllers running on hub to add finalizer on role/rolebinding for work agent. It ensures that all manifest works in a certain cluster namespace are deleted before role/rolebinding in the same namespace is deleted.