### PR TITLE
Delete resources applied by controller only

### DIFF
--- a/pkg/helper/helper_test.go
+++ b/pkg/helper/helper_test.go
@@ -348,7 +348,6 @@ func TestDeleteAppliedResourcess(t *testing.T) {
 				{Version: "v1", Resource: "secrets", Namespace: "ns2", Name: "n2", UID: "ns2-n2"},
 			},
 			expectedResourcesPendingFinalization: []workapiv1.AppliedManifestResourceMeta{
-				{Version: "v1", Resource: "secrets", Namespace: "ns1", Name: "n1", UID: "ns1-n1"},
 				{Version: "v1", Resource: "secrets", Namespace: "ns2", Name: "n2", UID: "ns2-n2"},
 			},
 		},

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
@@ -264,6 +265,7 @@ func UpdateManifestWorkStatus(
 }
 
 // DeleteAppliedResources deletes all given applied resources and returns those pending for finalization
+// If the uid recorded in resources is different from what we get by client, ignore the deletion.
 func DeleteAppliedResources(resources []workapiv1.AppliedManifestResourceMeta, dynamicClient dynamic.Interface) ([]workapiv1.AppliedManifestResourceMeta, []error) {
 	var resourcesPendingFinalization []workapiv1.AppliedManifestResourceMeta
 	var errs []error
@@ -286,28 +288,18 @@ func DeleteAppliedResources(resources []workapiv1.AppliedManifestResourceMeta, d
 			continue
 		}
 
-		pendingFinalization := u.GetDeletionTimestamp() != nil && !u.GetDeletionTimestamp().IsZero()
-		waitingForFinalization := len(resource.UID) > 0
-		if pendingFinalization {
-			if waitingForFinalization && resource.UID != string(u.GetUID()) {
-				// the instance is deleted, so do not add to the resourcesPendingDeletion list
-				continue
-			}
-
-			// if we aren't waiting for finalization or the UID does match, then we want to ensure we add it to the pending list
-			newResource := copyAppliedResource(resource)
-			newResource.UID = string(u.GetUID())
-			resourcesPendingFinalization = append(resourcesPendingFinalization, newResource)
+		if resource.UID != string(u.GetUID()) {
+			// the traced instance has been deleted, and forget this item.
 			continue
 		}
 
-		// forget this item if the UID does not match the resource UID we previously deleted
-		if waitingForFinalization && resource.UID != string(u.GetUID()) {
+		if u.GetDeletionTimestamp() != nil && !u.GetDeletionTimestamp().IsZero() {
+			resourcesPendingFinalization = append(resourcesPendingFinalization, resource)
 			continue
 		}
 
 		// delete the resource which is not deleted yet
-		uid := u.GetUID()
+		uid := types.UID(resource.UID)
 		err = dynamicClient.
 			Resource(gvr).
 			Namespace(resource.Namespace).
@@ -330,25 +322,11 @@ func DeleteAppliedResources(resources []workapiv1.AppliedManifestResourceMeta, d
 			continue
 		}
 
-		// set UID of applied resource once deletion is successful
-		newResource := copyAppliedResource(resource)
-		newResource.UID = string(u.GetUID())
-		resourcesPendingFinalization = append(resourcesPendingFinalization, newResource)
+		resourcesPendingFinalization = append(resourcesPendingFinalization, resource)
 		klog.V(2).Infof("Delete resource %v with key %s/%s", gvr, resource.Namespace, resource.Name)
 	}
 
 	return resourcesPendingFinalization, errs
-}
-
-func copyAppliedResource(resource workapiv1.AppliedManifestResourceMeta) workapiv1.AppliedManifestResourceMeta {
-	return workapiv1.AppliedManifestResourceMeta{
-		Group:     resource.Group,
-		Version:   resource.Version,
-		Resource:  resource.Resource,
-		Name:      resource.Name,
-		Namespace: resource.Namespace,
-		UID:       resource.UID,
-	}
 }
 
 // GuessObjectGroupVersionKind returns GVK for the passed runtime object.

--- a/pkg/spoke/controllers/finalizercontroller/manifestwork_finalize_controller_test.go
+++ b/pkg/spoke/controllers/finalizercontroller/manifestwork_finalize_controller_test.go
@@ -186,7 +186,6 @@ func TestSyncManifestWorkController(t *testing.T) {
 				},
 			},
 			validateAppliedManifestWorkActions: func(t *testing.T, actions []clienttesting.Action) {
-				fmt.Printf("Actions are %#v\n", actions)
 				if len(actions) != 1 {
 					t.Errorf("Expect 2 actions on appliedmanifestwork, but have %d", len(actions))
 				}

--- a/test/e2e/work_agent_test.go
+++ b/test/e2e/work_agent_test.go
@@ -214,7 +214,17 @@ var _ = ginkgo.Describe("Work agent", func() {
 				{Version: "v1", Resource: "configmaps", Namespace: ns2, Name: "cm3"},
 				{Version: "v1", Resource: "namespaces", Name: ns1},
 			}
-			gomega.Expect(reflect.DeepEqual(appliedManifestWork.Status.AppliedResources, expectedAppliedResources)).To(gomega.BeTrue())
+			actualAppliedResources := []workapiv1.AppliedManifestResourceMeta{}
+			for _, appliedResource := range appliedManifestWork.Status.AppliedResources {
+				actualAppliedResources = append(actualAppliedResources, workapiv1.AppliedManifestResourceMeta{
+					Group:     appliedResource.Group,
+					Version:   appliedResource.Version,
+					Resource:  appliedResource.Resource,
+					Namespace: appliedResource.Namespace,
+					Name:      appliedResource.Name,
+				})
+			}
+			gomega.Expect(reflect.DeepEqual(actualAppliedResources, expectedAppliedResources)).To(gomega.BeTrue())
 
 			ginkgo.By("update manifestwork")
 			cmData := map[string]string{"x": "y"}

--- a/test/integration/util/assertion.go
+++ b/test/integration/util/assertion.go
@@ -181,6 +181,18 @@ func AssertAppliedResources(hubHash, workName string, gvrs []schema.GroupVersion
 			return false
 		}
 
-		return reflect.DeepEqual(appliedManifestWork.Status.AppliedResources, appliedResources)
+		// remove uid from each AppliedManifestResourceMeta
+		var actualAppliedResources []workapiv1.AppliedManifestResourceMeta
+		for _, appliedResource := range appliedManifestWork.Status.AppliedResources {
+			actualAppliedResources = append(actualAppliedResources, workapiv1.AppliedManifestResourceMeta{
+				Group:     appliedResource.Group,
+				Version:   appliedResource.Version,
+				Resource:  appliedResource.Resource,
+				Namespace: appliedResource.Namespace,
+				Name:      appliedResource.Name,
+			})
+		}
+
+		return reflect.DeepEqual(actualAppliedResources, appliedResources)
 	}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 }


### PR DESCRIPTION
To fix https://github.com/open-cluster-management/backlog/issues/4565, record UIDs once applying manifests and delete resources applied by controller only.