### PR TITLE
Delete resource anyway when work owned by multiple hubs is deleting

### DIFF
--- a/pkg/spoke/controllers/appliedmanifestcontroller/appliedmanifestwork_controller.go
+++ b/pkg/spoke/controllers/appliedmanifestcontroller/appliedmanifestwork_controller.go
@@ -161,7 +161,7 @@ func (m *AppliedManifestWorkController) syncManifestWork(
 	reason := fmt.Sprintf("it is no longer maintained by manifestwork %s", manifestWork.Name)
 
 	resourcesPendingFinalization, errs := helper.DeleteAppliedResources(
-		noLongerMaintainedResources, reason, m.spokeDynamicClient, controllerContext.Recorder(), *owner)
+		noLongerMaintainedResources, reason, m.spokeDynamicClient, controllerContext.Recorder(), m.hubHash, *owner)
 	if len(errs) != 0 {
 		return utilerrors.NewAggregate(errs)
 	}

--- a/pkg/spoke/spokeagent.go
+++ b/pkg/spoke/spokeagent.go
@@ -113,6 +113,7 @@ func (o *WorkloadAgentOptions) RunWorkloadAgent(ctx context.Context, controllerC
 	appliedManifestWorkFinalizeController := finalizercontroller.NewAppliedManifestWorkFinalizeController(
 		controllerContext.EventRecorder,
 		spokeDynamicClient,
+		hubhash,
 		spokeWorkClient.WorkV1().AppliedManifestWorks(),
 		spokeWorkInformerFactory.Work().V1().AppliedManifestWorks(),
 	)


### PR DESCRIPTION
If the resource applied by work has multiple owners, the resource will
not be removed when the work is deleted. However, we need to remove the
resource anyway if the resource is owned by different hubs. This is
because the hub could be switched to a new one, while previous hub
cannot own the resource anymore.

Signed-off-by: Jian Qiu <jqiu@redhat.com>